### PR TITLE
Lower case tcp

### DIFF
--- a/images/vsftpd/Dockerfile.alpine
+++ b/images/vsftpd/Dockerfile.alpine
@@ -34,5 +34,5 @@ RUN adduser --home /home/ftp --shell /sbin/nologin --uid ${UID} --disabled-passw
 # Add the required VSFTPd dependencies and tzdata so that users can set timezones via environment variables. And create an empty directory used as a secure chroot() jail VSFTPd.
 RUN apk add --no-cache linux-pam-dev openssl-dev tzdata && mkdir -m 744 -p /var/run/vsftpd/empty
 
-EXPOSE 21/TCP 20/TCP
+EXPOSE 21/tcp 20/tcp
 CMD ["/usr/sbin/vsftpd","/etc/vsftpd/vsftpd.conf"]

--- a/images/vsftpd/Dockerfile.ubuntu
+++ b/images/vsftpd/Dockerfile.ubuntu
@@ -34,6 +34,6 @@ RUN adduser --home /home/ftp --shell /sbin/nologin --uid ${UID} --disabled-passw
 # Add the required VSFTPd dependencies and tzdata so that users can set timezones via environment variables. And create an empty directory used as a secure chroot() jail VSFTPd.
 RUN apt -y update && apt install -y tzdata libssl-dev && apt -y clean && mkdir -m 744 -p /var/run/vsftpd/empty
 
-EXPOSE 21/TCP 20/TCP
+EXPOSE 21/tcp 20/tcp
 CMD ["/usr/sbin/vsftpd","/etc/vsftpd/vsftpd.conf"]
 


### PR DESCRIPTION
I changed "TCP" to "tcp" in the EXPOSE commands. The Dockerfile reference uses lower case in the examples, but doesn't specify whether upper case should be acceptable. The "docker build" command accepts either case, but Kaniko only accepts lower case. 